### PR TITLE
Legible output: text decoration in output

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Text decoration
+Red="\033[0;31m"
+Bold="\033[1m"
+Color_Off="\033[0m"
+Cyan="\033[0;36m"
+Green="\033[0;32m"
+
 # Find Cisco Packet Tracer installer
 installer_name_1=CiscoPacketTracer*Ubuntu_64bit.deb
 installer_name_2=Cisco_Packet_Tracer_*_Ubuntu_64bit_*.deb
@@ -7,15 +14,18 @@ installer_name_3=Cisco*.deb
 path_to_pt=$(find /home -name $installer_name_1 -o -name $installer_name_2 -o -name $installer_name_3)
 
 if [[ -z "$path_to_pt" ]]; then
-    echo "Packet Tracer installer not found in /home. It must be named like this: $installer_name_1."
-    echo "You can download the installer from https://www.netacad.com/portal/resources/packet-tracer"
-    echo "or https://skillsforall.com/resources/lab-downloads (login required)."
+    echo -e "\n\n${Red}${Bold}Packet Tracer installer not found in /home. It must be named like this: $installer_name_1.$Color_Off\n"
+    echo -e "You can download the installer from ${Cyan}https://www.netacad.com/portal/resources/packet-tracer${Color_Off} \
+or ${Cyan}https://skillsforall.com/resources/lab-downloads${Color_Off} (login required)."
     exit 1
+else
+    echo -e "\nThe Packet Tracer installer was found at:"
+    echo -e "${Green}${Bold}$path_to_pt${Color_Off}\n"
+    sleep 3
 fi
 
-if [ -e /opt/pt ]; then
-  sudo bash ./uninstall.sh
-fi
+echo "Removing old version of Packet Tracer from /opt/pt"
+sudo bash ./uninstall.sh
 
 echo "Extracting files"
 mkdir packettracer
@@ -27,6 +37,7 @@ sudo cp -r packettracer/usr /
 sudo cp -r packettracer/opt /
 sudo sed -i 's/packettracer/packettracer --no-sandbox args/' /usr/share/applications/cisco-pt.desktop
 sudo sed -i 's/sudo xdg-mime/sudo -u $SUDO_USER xdg-mime/' ./packettracer/postinst 
+sudo sed -i 's/sudo gtk-update-icon-cache --force/sudo gtk-update-icon-cache -t --force/' ./packettracer/postinst
 sudo ./packettracer/postinst
 
 echo "Installing dependencies"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,11 +3,11 @@
 # Remove Cisco Packet Tracer
 
 if [ -e /opt/pt ]; then
-  echo "Removing old version of Packet Tracer from /opt/pt"
+  echo "Uninstalling Cisco Packet Tracer."
   sudo rm -rf /opt/pt /usr/share/applications/cisco*-pt*.desktop
   sudo xdg-desktop-menu uninstall /usr/share/applications/cisco-pt*.desktop
   sudo update-mime-database /usr/share/mime
-  sudo gtk-update-icon-cache --force /usr/share/icons/gnome
+  sudo gtk-update-icon-cache -t --force /usr/share/icons/gnome
   
   sudo rm -f /usr/local/bin/packettracer
 fi


### PR DESCRIPTION
- Now, the output of installer is more legible with more spaces before and after of important alerts, like "installer not found" or "installer found at `path`", and text decoration.
- `gtk-update-icon-cache` receive a flag `--ignore-theme-index` to solve a warning that informs can not localize theme file. (thanks @Ricky-Tigg)