### PR TITLE
fix name matching problem

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,14 +8,11 @@ Cyan="\033[0;36m"
 Green="\033[0;32m"
 
 # Find Cisco Packet Tracer installer
-installer_name_1=CiscoPacketTracer*Ubuntu_64bit.deb
-installer_name_2=Cisco_*.deb
-installer_name_3=Packet_Tracer*.deb
 localized_installers=()
 selected_installer=''
 
 c=1
-for installer in $(find /home -type f -name $installer_name_1 -o -name $installer_name_2 -o -name $installer_name_3); do
+for installer in $(find /home -type f -name "Cisco*Packet*.deb" -o -name "Packet*Tracer*.deb"); do
   echo $installer
   localized_installers[$c]=$installer
   ((c++))


### PR DESCRIPTION
Fix #40 
I changed the expression in find command to match the possible installer file names.

The problem is caused because Skills For All and NetAcad provides different installer names for same version of installer.