### PR TITLE
Packettracer.deb packages in user Download folder instead Home folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cisco Packet Tracer latest version on Fedora
 
-Easily install Cisco Packet Tracer latest version on Fedora. This installation script automatically detects a Cisco Packet Tracer `.deb` in any directory on `/home`.
+Easily install Cisco Packet Tracer latest version on Fedora. This installation script automatically detects a Cisco Packet Tracer `.deb` in any directory on `/home/users/Downloads`.
 
 ## Install
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Variables
+user=$(whoami)
+
 # Text decoration
 Red="\033[0;31m"
 Bold="\033[1m"

--- a/install.sh
+++ b/install.sh
@@ -15,13 +15,13 @@ localized_installers=()
 selected_installer=''
 
 c=1
-for installer in $(find /home -type f -name $installer_name_1 -o -name $installer_name_2 -o -name $installer_name_3); do
+for installer in $(find /home/$user/Downloads -type f -name $installer_name_1 -o -name $installer_name_2 -o -name $installer_name_3); do
   echo $installer
   localized_installers[$c]=$installer
   ((c++))
 done
 if [[ -z "${localized_installers[@]}" ]]; then
-  echo -e "\n\n${Red}${Bold}Packet Tracer installer not found in /home. It must be named like this: $installer_name_1.$Color_Off\n"
+  echo -e "\n\n${Red}${Bold}Packet Tracer installer not found in /home/$user/Downloads. It must be named like this: $installer_name_1.$Color_Off\n"
   echo -e "You can download the installer from ${Cyan}https://www.netacad.com/portal/resources/packet-tracer${Color_Off} \
 or ${Cyan}https://skillsforall.com/resources/lab-downloads${Color_Off} (login required)."
   exit 1


### PR DESCRIPTION
I notice that every time you download and install Packet Tracer, you have to move the installer to the /home directory.

Usually, when you download the Packet Tracer installer from the website, it automatically saves to the Downloads folder by the browser.

I made changes to the script so that instead of the /home folder, the script will scan for the installer .deb file in the /home/anyusers/Downloads folder.