### PR TITLE
Add Fedora 43+ FUSE2 compatibility note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Now, the script accepts these command line options:
 - [x] Fedora 41
 - [x] Fedora 42
 
+## Fedora 43+
+
+Packet Tracer 9 requires `libfuse.so.2` (FUSE2), which is not included by default in Fedora 43.  
+Before installing, run:
+
+```
+sudo dnf install fuse fuse-libs
+```
+
+
 > [!Note]
 > If you are using a distribution that is based on Fedora, this script will probably still work. If not, open an issue. I will not list any Fedora based distro here.
 


### PR DESCRIPTION
This PR updates the README to help Fedora 43+ users successfully
install Packet Tracer 9 using the setup script.

### Changes
- Added a new section under "Fedora 43+" explaining that
  Packet Tracer 9 requires libfuse.so.2 (FUSE2), which is not
  included by default in Fedora 43.
- Provided the command to install the necessary packages:
  sudo dnf install fuse fuse-libs

### Benefits
- Users on Fedora 43 can install Packet Tracer 9 without encountering
  AppImage FUSE errors.
- Improves documentation clarity for newer Fedora releases.

### Notes
- This is a documentation-only change; no code modifications.
