### PR TITLE
feat: Prioritize SUDO_USER for user name detection.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ Bold="\033[1m"
 Color_Off="\033[0m"
 Cyan="\033[0;36m"
 Green="\033[0;32m"
-user_name=$(who | cut -d ' ' -f 1 | head -1)
+user_name="${SUDO_USER:-$(who | cut -d ' ' -f 1 | head -1)}"
 installer_search_path="/home/$user_name"
 USAGE_MESSAGE="Usage: $0 [OPTIONS]... [DIRECTORY]...
 Install Cisco Packet Tracer latest version on Fedora Linux using


### PR DESCRIPTION
Prefer `$SUDO_USER` when resolving the current user and fallback to the previous `who` logic.

This fixes issues where the script was executed with `sudo` and the wrong home directory was used.