### PR TITLE
fix: resolve incorrect home directory when running with sudo

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ Bold="\033[1m"
 Color_Off="\033[0m"
 Cyan="\033[0;36m"
 Green="\033[0;32m"
-user_name=$(who | cut -d ' ' -f 1 | head -1)
+user_name=$(logname 2>/dev/null || echo "${SUDO_USER:-$USER}")
 installer_search_path="/home/$user_name"
 USAGE_MESSAGE="Usage: $0 [OPTIONS]... [DIRECTORY]...
 Install Cisco Packet Tracer latest version on Fedora Linux using
@@ -21,7 +21,7 @@ install () {
   echo "Extracting files"
   echo "Installing dependencies"
   sudo dnf -y install binutils fuse fuse-libs qt5-qttools
-  ! test -d /home/$user_name/.local/share/applications && sudo mkdir /home/$user_name/.local/share/applications
+  ! test -d /home/$user_name/.local/share/applications && sudo mkdir -p /home/$user_name/.local/share/applications
   mkdir packettracer
   ar -x $selected_installer --output=packettracer
   tar -xvf packettracer/control.tar.xz --directory=packettracer


### PR DESCRIPTION
## Problem
When running `sudo bash setup.sh`, the `who` command returns `root`, causing `user_name` to be set to `root` and the script to attempt creating `/home/root/.local/share/applications` - a path that doesn't exist on most systems (root's home is `/root`).

This causes the installation to fail with:
```
mkdir: cannot create directory '/home/root/.local/share/applications': No such file or directory
```

## Fix
- Replace `who | cut -d ' ' -f 1 | head -1` with `logname 2>/dev/null || echo "${SUDO_USER:-$USER}"` to correctly resolve the actual logged-in user regardless of how the script is invoked
- Add `-p` flag to `mkdir` to safely create parent directories if missing

## Testing
- Confirmed broken on Fedora 43 with `sudo bash setup.sh`
- Fix works on Fedora 43
- Changes use only standard coreutils tools available on all supported Fedora versions (F40, F41, F42, F43)